### PR TITLE
Replace Satisfy with BeAs to test the response models

### DIFF
--- a/Calzolari.WebApi.Tests/CountryControllerTests/GetByIdTests.cs
+++ b/Calzolari.WebApi.Tests/CountryControllerTests/GetByIdTests.cs
@@ -35,10 +35,7 @@ namespace Calzolari.WebApi.Tests.CountryControllerTests
                 .Should()
                 .Be200Ok()
                 .And
-                .Satisfy<Country>(model =>
-                {
-                    model.Should().BeEquivalentTo(country);
-                });
+                .BeAs(country);
         }
 
 

--- a/Calzolari.WebApi.Tests/CountryControllerTests/GetTests.cs
+++ b/Calzolari.WebApi.Tests/CountryControllerTests/GetTests.cs
@@ -35,13 +35,10 @@ namespace Calzolari.WebApi.Tests.CountryControllerTests
 
             // Assert
             response.ResponseMessage
-                    .Should()
-                    .Be200Ok()
-                    .And
-                    .Satisfy<IEnumerable<Country>>(model =>
-            {
-                model.Should().BeEquivalentTo(countries);
-            });
+                .Should()
+                .Be200Ok()
+                .And
+                .BeAs(countries);
         }
 
         [Fact]

--- a/Calzolari.WebApi.Tests/CountryControllerTests/PostTests.cs
+++ b/Calzolari.WebApi.Tests/CountryControllerTests/PostTests.cs
@@ -36,13 +36,13 @@ namespace Calzolari.WebApi.Tests.CountryControllerTests
             // Assert
             var test = await response.ResponseMessage.Content.ReadAsStringAsync();
             response.ResponseMessage
-                    .Should()
-                    .Be201Created()
-                    .And.Satisfy<Country>(model =>
-                    {
-                        model.Description.Should().Be(country.Description);
-                        model.CountryName.Should().Be(country.CountryName);
-                    });
+                .Should()
+                .Be201Created()
+                .And.BeAs(new
+                {
+                    country.CountryName,
+                    country.Description
+                });
         }
 
         [Fact]


### PR DESCRIPTION
Some of the tests that use the _Satisfy_ assertion could be simplified with _BeAs_

Thanks for checking FluentAssertions.Web :)